### PR TITLE
[WIP] Add log handler for writing errors to file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.so
 *.dylib
 bin/*
+logs/*
 Dockerfile.cross
 
 # Test binary, built with `go test -c`

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -1,0 +1,53 @@
+package logger
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// Global logger
+// since we are running a TUI, we dont want to write to stdout,
+// so we will write to stderr + a log file
+var errorLogger *log.Logger
+
+func init() {
+	initLog()
+}
+
+// initLog creates a new log file with a timestamped name each run.
+func initLog() (*os.File, error) {
+	logDir := "logs"
+	err := os.MkdirAll(logDir, 0755)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create log directory: %w", err)
+	} else {
+		fmt.Printf("Log directory '%s' created or already exists\n", logDir)
+	}
+
+	timestamp := time.Now().Format("2006-01-02_15-04-05")
+	filename := filepath.Join(logDir, fmt.Sprintf("signalhound_%s.log", timestamp))
+
+	file, err := os.OpenFile(filename, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open log file: %w", err)
+	} else {
+		fmt.Printf("Log file %s created\n", filename)
+	}
+
+	// Create a logger that writes to both file and stderr
+	errorLogger = log.New(file, "ERROR: ", log.Ldate|log.Ltime|log.Lshortfile)
+	return file, nil
+}
+
+// HandleError logs errors bot to stderr and also a log file
+func HandleError(err error) {
+	if err != nil {
+		// Print to stderr
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		// Log to file
+		errorLogger.Println(err)
+	}
+}


### PR DESCRIPTION
Address issue #7

A quick prototype PR to get a conversation started.

Creates a `/logs` dir on the file system and a new log file on each run:

<img width="314" height="77" alt="Screenshot 2025-11-06 at 2 42 03 PM" src="https://github.com/user-attachments/assets/ff77d9b2-ae83-4ab3-8267-205cbb2ad253" />

Contents of log file are something like:

```
ERROR: 2025/11/06 14:39:37 logger.go:51: non-200 OK status code: 401 Unauthorized body: "{\r\n  \"message\": \"Bad credentials\",\r\n  \"documentation_url\": \"https://docs.github.com/rest\",\r\n  \"status\": \"401\"\r\n}"
```

Currently the log message along the footer of SignalHound can be truncated for the same error message:

<img width="852" height="144" alt="Screenshot 2025-11-06 at 2 43 20 PM" src="https://github.com/user-attachments/assets/b4fbaeb3-bcee-47e5-9ab0-e5409f114b6e" />

@knabben 


