### PR TITLE
[WIP] Add GITHUB_ISSUE_EXISTS to GitHub tab state

### DIFF
--- a/internal/tui/panel.go
+++ b/internal/tui/panel.go
@@ -74,7 +74,7 @@ func RenderVisual(tabs []*v1alpha1.DashboardTab, githubToken string) error {
 
 	// GitHub panel rendering
 	setPanelDefaultStyle(githubPanel.Box)
-	githubPanel.SetTitle(formatTitle("Github Issue"))
+	githubPanel.SetTitle(formatTitle("Github Issue Exists!"))
 	githubPanel.SetWrap(true)
 
 	// Final position bottom panel for information
@@ -181,6 +181,11 @@ func updateGitHubPanel(tab *v1alpha1.DashboardTab, currentTest *v1alpha1.TestRes
 	if tab.TabState == v1alpha1.FAILING_STATUS {
 		templateFile, prefixTitle = "template/failure.tmpl", "Failing Test"
 	}
+	// TODO: add status of "GITHUB_ISSUE_EXISTS" and load different template
+	// if tab.TabState == v1alpha1.GITHUB_ISSUE_EXISTS_STATUS {
+	templateFile, prefixTitle = "template/github-issue-exists.tmpl", "GitHub Issue Exists"
+	// }
+
 	template, err := renderTemplate(issue, templateFile)
 	if err != nil {
 		position.SetText(fmt.Sprintf("[red]error: %v", err.Error()))

--- a/internal/tui/template/github-issue-exists.tmpl
+++ b/internal/tui/template/github-issue-exists.tmpl
@@ -1,0 +1,8 @@
+### GitHub Issue Title
+
+ClusterLoaderV2.access-tokens: [step: 02] Creating ServiceAccounts
+
+### GitHub Issue URL
+
+https://testgrid.k8s.io/sig-release-master-informing#ec2-master-scale-performance
+


### PR DESCRIPTION
Address #6 

Quick stub-in of the panel:

<img width="450" height="421" alt="Screenshot 2025-11-06 at 2 52 08 PM" src="https://github.com/user-attachments/assets/f9c6068c-435c-4abe-9a20-1de7b8597fe2" />

The trick here is that tests are not necessarily consistently reported.  To query GitHub for matching issues, we may need something like https://github.com/kubernetes/kubernetes/pull/135194/files to ensure that consistent information is contained in the issue. 