### PR TITLE
Migrate module path to sigs.k8s.io/signalhound

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ export GITHUB_TOKEN=<github.pat.default>
 ### Running at runtime
 
 ```bash
-git clone https://github.com/knabben/signalhound.git
+git clone https://github.com/kubernetes-sigs/signalhound.git
 cd signalhound
 make run  # for abstract and standalone
 make run-controller # for running the controller outside the cluster

--- a/cmd/abstract.go
+++ b/cmd/abstract.go
@@ -1,4 +1,18 @@
-/* Copyright 2025 Amim Knabben */
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 
 package cmd
 
@@ -6,10 +20,10 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/knabben/signalhound/api/v1alpha1"
-	"github.com/knabben/signalhound/internal/testgrid"
-	"github.com/knabben/signalhound/internal/tui"
 	"github.com/spf13/cobra"
+	"sigs.k8s.io/signalhound/api/v1alpha1"
+	"sigs.k8s.io/signalhound/internal/testgrid"
+	"sigs.k8s.io/signalhound/internal/tui"
 )
 
 // abstractCmd represents the abstract command

--- a/cmd/controller.go
+++ b/cmd/controller.go
@@ -1,4 +1,18 @@
-/* Copyright 2025 Amim Knabben */
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 
 package cmd
 
@@ -22,8 +36,8 @@ import (
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
-	testgridv1alpha1 "github.com/knabben/signalhound/api/v1alpha1"
-	"github.com/knabben/signalhound/internal/controller"
+	testgridv1alpha1 "sigs.k8s.io/signalhound/api/v1alpha1"
+	"sigs.k8s.io/signalhound/internal/controller"
 	// +kubebuilder:scaffold:imports
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/knabben/signalhound
+module sigs.k8s.io/signalhound
 
 go 1.25.1
 

--- a/internal/controller/dashboard_controller.go
+++ b/internal/controller/dashboard_controller.go
@@ -25,8 +25,6 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
-	testgridv1alpha1 "github.com/knabben/signalhound/api/v1alpha1"
-	"github.com/knabben/signalhound/internal/testgrid"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -34,6 +32,8 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	testgridv1alpha1 "sigs.k8s.io/signalhound/api/v1alpha1"
+	"sigs.k8s.io/signalhound/internal/testgrid"
 )
 
 // DashboardReconciler reconciles a Dashboard object

--- a/internal/controller/dashboard_controller_test.go
+++ b/internal/controller/dashboard_controller_test.go
@@ -27,7 +27,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	testgridv1alpha1 "github.com/knabben/signalhound/api/v1alpha1"
+	testgridv1alpha1 "sigs.k8s.io/signalhound/api/v1alpha1"
 )
 
 var _ = Describe("Dashboard Controller", func() {

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -32,7 +32,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	testgridv1alpha1 "github.com/knabben/signalhound/api/v1alpha1"
+	testgridv1alpha1 "sigs.k8s.io/signalhound/api/v1alpha1"
 	// +kubebuilder:scaffold:imports
 )
 

--- a/internal/testgrid/testgrid.go
+++ b/internal/testgrid/testgrid.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/knabben/signalhound/api/v1alpha1"
-	"github.com/knabben/signalhound/internal/prow"
+	"sigs.k8s.io/signalhound/api/v1alpha1"
+	"sigs.k8s.io/signalhound/internal/prow"
 )
 
 var (

--- a/internal/testgrid/testgrid_test.go
+++ b/internal/testgrid/testgrid_test.go
@@ -6,8 +6,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/knabben/signalhound/api/v1alpha1"
 	"github.com/stretchr/testify/assert"
+	"sigs.k8s.io/signalhound/api/v1alpha1"
 )
 
 const dashboard, tabName = "sig-release-blocking", "kubernetes-ci"

--- a/internal/tui/panel.go
+++ b/internal/tui/panel.go
@@ -9,11 +9,11 @@ import (
 	"time"
 
 	"github.com/gdamore/tcell/v2"
-	"github.com/knabben/signalhound/api/v1alpha1"
-	"github.com/knabben/signalhound/internal/github"
 	"github.com/rivo/tview"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
+	"sigs.k8s.io/signalhound/api/v1alpha1"
+	"sigs.k8s.io/signalhound/internal/github"
 )
 
 var (

--- a/main.go
+++ b/main.go
@@ -1,9 +1,22 @@
 /*
-Copyright © 2025 Amim Knabben
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 */
+
 package main
 
-import "github.com/knabben/signalhound/cmd"
+import "sigs.k8s.io/signalhound/cmd"
 
 func main() {
 	cmd.Execute()

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -25,7 +25,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/knabben/signalhound/test/utils"
+	"sigs.k8s.io/signalhound/test/utils"
 )
 
 var (

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -27,7 +27,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/knabben/signalhound/test/utils"
+	"sigs.k8s.io/signalhound/test/utils"
 )
 
 // namespace where the project is deployed in


### PR DESCRIPTION
We already have `sigs.k8s.io/signalhound` redirecting to `github.com/kubernetes-sigs/signalhound`.

Also, the address `https://sigs.k8s.io/signalhound?go-get=1` already works as expected by `go install` so we can safely change the module path to the new address, so users can `go install sigs.k8s.io/signalhound`. 

The icing on the cake would be to do our first release, just so we have a `@latest` tag. 🐶 