### PR TITLE
Bug: devcontainer: build fails on golang:1.24 image due to debian trixie/moby incompatibility

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,9 @@
   "name": "Kubebuilder DevContainer",
   "image": "docker.io/golang:1.24-bookworm",
   "features": {
-    "ghcr.io/devcontainers/features/docker-in-docker:2": {},
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {
+      "moby": false
+    },
     "ghcr.io/devcontainers/features/git:1": {}
   },
 


### PR DESCRIPTION
**Which issue(s) this PR fixes:**
Fixes [#36](https://github.com/kubernetes-sigs/signalhound/issues/36)

Testing locally confirms that using the bookworm variant resolves the repository resolution errors encountered with the default trixie-based image. 

**Does this PR introduce a user-facing change?**
No.