### PR TITLE
Correct GitHub casing

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Prerequisites
 
 * Go 1.24 or later
 * Git
-* Github Token PAT
+* GitHub Token PAT
 * Kubernetes cluster (kind)
 
 ### Prerequisites

--- a/internal/tui/panel.go
+++ b/internal/tui/panel.go
@@ -190,7 +190,7 @@ func RenderVisual(tabs []*v1alpha1.DashboardTab, token string, refreshInterval t
 
 	// GitHub panel rendering
 	setPanelDefaultStyle(githubPanel.Box)
-	githubPanel.SetTitle(formatTitle("Github Issue"))
+	githubPanel.SetTitle(formatTitle("GitHub Issue"))
 	githubPanel.SetWrap(true).SetDisabled(true)
 	githubPanel.SetTextStyle(tcell.StyleDefault)
 


### PR DESCRIPTION
There were a couple places where GitHub was not correctly cased, showing up in the TUI. This fixes the instances in the code and README.