### PR TITLE
Add dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      otel:
+        patterns:
+          - "*opentelemetry.io*"
+      prom:
+        patterns:
+          - "*prometheus*"
+      k8s:
+        patterns:
+          - "*k8s.io*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
This adds configuration for Go, Dockerfile, and GHA dependencies to receive updates via Dependabot. For Go dependencies it defines groups for the things that should usually be taken as a set to reduce the number of PRs.