### PR TITLE
Add dependabot grouping for ginkgo deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,9 @@ updates:
       k8s:
         patterns:
           - "*k8s.io*"
+      ginkgo:
+        patterns:
+          - "*onsi*"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
The ginkgo and gomega libraries are usually released together and related. To avoid merge conflicts and extra CI time, and reduce the number of PRs to review, this groups those dependency updates into one set.