### PR TITLE
dependabot: Group golang.org/x package updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,9 @@ updates:
       ginkgo:
         patterns:
           - "*onsi*"
+      golangx:
+        patterns:
+          - "*golang.org/x/*"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
There are a few different packages under golang.org/x that are generally releases together. We usually want to take all of these updates. So this groups them into one so a single PR will be created for all of them together and we can avoid merge conflicts and extra PRs.