### PR TITLE
Add `--dashboards` flag to support custom TestGrid dashboards

### DIFF
--- a/cmd/abstract.go
+++ b/cmd/abstract.go
@@ -21,11 +21,14 @@ var abstractCmd = &cobra.Command{
 	RunE:  RunAbstract,
 }
 
+var defaultDashboards = []string{"sig-release-master-blocking", "sig-release-master-informing"}
+
 var (
 	tg                   = testgrid.NewTestGrid(testgrid.URL)
 	minFailure, minFlake int
 	refreshInterval      int
 	token                string
+	dashboards           []string
 )
 
 func init() {
@@ -37,6 +40,8 @@ func init() {
 		"minimum threshold for test flakeness, to disable use 0. Defaults to 0.")
 	abstractCmd.PersistentFlags().IntVarP(&refreshInterval, "refresh-interval", "r", 0,
 		"refresh interval in seconds (0 to disable auto-refresh)")
+	abstractCmd.PersistentFlags().StringSliceVarP(&dashboards, "dashboards", "d", defaultDashboards,
+		"comma-separated list of TestGrid dashboards to monitor (e.g. sig-release-1.35-blocking,sig-release-1.35-informing)")
 
 	token = os.Getenv("SIGNALHOUND_GITHUB_TOKEN")
 	if token == "" {
@@ -47,7 +52,7 @@ func init() {
 // FetchTabSummary fetches all dashboard tabs from TestGrid.
 func FetchTabSummary() ([]*v1alpha1.DashboardTab, error) {
 	var dashboardTabs []*v1alpha1.DashboardTab
-	for _, dashboard := range []string{"sig-release-master-blocking", "sig-release-master-informing"} {
+	for _, dashboard := range dashboards {
 		dashSummaries, err := tg.FetchTabSummary(dashboard, v1alpha1.ERROR_STATUSES)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Fixed #35

- Add a `--dashboards` / `-d` flag to the abstract command, allowing users to specify custom TestGrid dashboards to monitor
- Defaults to `sig-release-master-blocking` and `sig-release-master-informing` (no behavior change for existing users)
- Supports comma-separated values (e.g. `-d sig-release-1.35-blocking,sig-release-1.35-informing`) or repeated flags (e.g. `-d sig-release-1.35-blocking -d sig-release-1.35-informing`)