### PR TITLE
ci: Only run workflows on activity to main

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,7 +2,11 @@ name: Lint
 
 on:
   push:
+    branches:
+      - main
   pull_request:
+    branches:
+      - main
 
 jobs:
   lint:
@@ -15,7 +19,6 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.25.1'
           go-version-file: go.mod
 
       - name: Run linter

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -2,7 +2,11 @@ name: E2E Tests
 
 on:
   push:
+    branches:
+      - main
   pull_request:
+    branches:
+      - main
 
 jobs:
   test-e2e:
@@ -15,7 +19,6 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.25.1'
           go-version-file: go.mod
 
       - name: Install the latest version of kind


### PR DESCRIPTION
This adds branch filtering to make sure GitHub Action workflows only run when code is proposed (pull request) or merged (push) to the main branch. This reduces duplicate and unnecessary workflows.

Also removes extraneous Go version config from the setup-go workflow. It should be configured to either use an explicit version or the version from the go.mod file. It was configured with both values, silently ignoring the explicit version.