### PR TITLE
Add stmcginnis to OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -8,6 +8,7 @@ approvers:
   - knabben
   - tico88612
   - Prajyot-Parab # Release Signal v1.36 Lead
+  - stmcginnis
 reviewers:
   - release-engineering-reviewers
 labels:


### PR DESCRIPTION
Proposing adding myself to OWNERS. I have been watching activity and reviewing for some time and think it would be helpful to be able to approve things like dependabot updates and the simpler things while my experience with signalhound grows.