### PR TITLE
Detect historical flakes in passing TestGrid tabs

### DIFF
--- a/cmd/abstract.go
+++ b/cmd/abstract.go
@@ -5,6 +5,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"sync"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -22,6 +23,15 @@ var abstractCmd = &cobra.Command{
 }
 
 var defaultDashboards = []string{"sig-release-master-blocking", "sig-release-master-informing"}
+
+const maxConcurrentTabFetches = 8
+
+// Passing tabs can still contain historical failures outside TestGrid's summary window.
+var monitoredStatuses = []string{
+	v1alpha1.PASSING_STATUS,
+	v1alpha1.FAILING_STATUS,
+	v1alpha1.FLAKY_STATUS,
+}
 
 var (
 	tg                   = testgrid.NewTestGrid(testgrid.URL)
@@ -53,22 +63,48 @@ func init() {
 func FetchTabSummary() ([]*v1alpha1.DashboardTab, error) {
 	var dashboardTabs []*v1alpha1.DashboardTab
 	for _, dashboard := range dashboards {
-		dashSummaries, err := tg.FetchTabSummary(dashboard, v1alpha1.ERROR_STATUSES)
+		dashSummaries, err := tg.FetchTabSummary(dashboard, monitoredStatuses)
 		if err != nil {
 			return nil, err
 		}
-		for _, dashSummary := range dashSummaries {
-			dashTab, err := tg.FetchTabTests(&dashSummary, minFailure, minFlake)
-			if err != nil {
-				fmt.Println(fmt.Errorf("error fetching table : %s", err))
-				continue
-			}
-			if len(dashTab.TestRuns) > 0 {
-				dashboardTabs = append(dashboardTabs, dashTab)
-			}
-		}
+		dashboardTabs = append(dashboardTabs, fetchDashboardTabs(dashSummaries)...)
 	}
 	return dashboardTabs, nil
+}
+
+func fetchDashboardTabs(summaries []v1alpha1.DashboardSummary) []*v1alpha1.DashboardTab {
+	type fetchResult struct {
+		tab *v1alpha1.DashboardTab
+		err error
+	}
+
+	results := make([]fetchResult, len(summaries))
+	semaphore := make(chan struct{}, maxConcurrentTabFetches)
+	var waitGroup sync.WaitGroup
+
+	for i := range summaries {
+		waitGroup.Add(1)
+		go func() {
+			defer waitGroup.Done()
+			semaphore <- struct{}{}
+			defer func() { <-semaphore }()
+
+			results[i].tab, results[i].err = tg.FetchTabTests(&summaries[i], minFailure, minFlake)
+		}()
+	}
+	waitGroup.Wait()
+
+	dashboardTabs := make([]*v1alpha1.DashboardTab, 0, len(results))
+	for _, result := range results {
+		if result.err != nil {
+			fmt.Println(fmt.Errorf("error fetching table: %w", result.err))
+			continue
+		}
+		if len(result.tab.TestRuns) > 0 {
+			dashboardTabs = append(dashboardTabs, result.tab)
+		}
+	}
+	return dashboardTabs
 }
 
 // RunAbstract starts the main command to scrape TestGrid.

--- a/cmd/abstract_test.go
+++ b/cmd/abstract_test.go
@@ -1,0 +1,156 @@
+/* Copyright 2026 The Kubernetes Authors. */
+
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"sigs.k8s.io/signalhound/api/v1alpha1"
+	"sigs.k8s.io/signalhound/internal/testgrid"
+)
+
+const (
+	testDashboardName  = "test-dashboard"
+	testgridStatusFail = 12
+)
+
+func TestFetchTabSummaryIncludesHistoricalFailuresFromPassingTabs(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		writer.Header().Set("Content-Type", "application/json")
+		if request.URL.Path == "/test-dashboard/summary" {
+			if err := json.NewEncoder(writer).Encode(testgrid.DashboardMapper{
+				"test-tab": {
+					OverallState:  v1alpha1.PASSING_STATUS,
+					DashboardName: testDashboardName,
+				},
+			}); err != nil {
+				http.Error(writer, err.Error(), http.StatusInternalServerError)
+			}
+			return
+		}
+
+		if err := json.NewEncoder(writer).Encode(testgrid.TestGroup{
+			Query:       "kubernetes-ci-logs/logs/test-job",
+			Timestamps:  []int64{1_758_999_193_000},
+			Changelists: []string{"1972011571991285760"},
+			Tests: []testgrid.Test{
+				{
+					Name:       "historical failure",
+					ShortTexts: []string{"F"},
+					Messages:   []string{"failed"},
+					Statuses:   []testgrid.Statuses{{Count: 1, Value: testgridStatusFail}},
+				},
+			},
+		}); err != nil {
+			http.Error(writer, err.Error(), http.StatusInternalServerError)
+		}
+	}))
+	defer server.Close()
+
+	previousTestGrid := tg
+	previousDashboards := dashboards
+	previousMinFailure, previousMinFlake := minFailure, minFlake
+	defer func() {
+		tg = previousTestGrid
+		dashboards = previousDashboards
+		minFailure, minFlake = previousMinFailure, previousMinFlake
+	}()
+
+	tg = testgrid.NewTestGrid(server.URL)
+	dashboards = []string{testDashboardName}
+	minFailure, minFlake = 0, 0
+
+	tabs, err := FetchTabSummary()
+
+	require.NoError(t, err)
+	require.Len(t, tabs, 1)
+	assert.Equal(t, v1alpha1.FLAKY_STATUS, tabs[0].TabState)
+	assert.Len(t, tabs[0].TestRuns, 1)
+}
+
+func TestFetchDashboardTabsBoundsConcurrencyAndPreservesOrder(t *testing.T) {
+	const summaryCount = maxConcurrentTabFetches + 4
+
+	var activeRequests int32
+	var peakRequests int32
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		current := atomic.AddInt32(&activeRequests, 1)
+		defer atomic.AddInt32(&activeRequests, -1)
+		for {
+			peak := atomic.LoadInt32(&peakRequests)
+			if current <= peak || atomic.CompareAndSwapInt32(&peakRequests, peak, current) {
+				break
+			}
+		}
+
+		index, err := strconv.Atoi(strings.TrimPrefix(request.URL.Path, "/"))
+		if err != nil {
+			http.Error(writer, err.Error(), http.StatusBadRequest)
+			return
+		}
+		time.Sleep(time.Duration(summaryCount-index) * 10 * time.Millisecond)
+		writer.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(writer).Encode(testgrid.TestGroup{
+			Query:       fmt.Sprintf("kubernetes-ci-logs/logs/test-job-%d", index),
+			Timestamps:  []int64{1_758_999_193_000},
+			Changelists: []string{"1972011571991285760"},
+			Tests: []testgrid.Test{
+				{
+					Name:       "historical failure",
+					ShortTexts: []string{"F"},
+					Messages:   []string{"failed"},
+					Statuses:   []testgrid.Statuses{{Count: 1, Value: testgridStatusFail}},
+				},
+			},
+		}); err != nil {
+			http.Error(writer, err.Error(), http.StatusInternalServerError)
+		}
+	}))
+	defer server.Close()
+
+	previousTestGrid := tg
+	previousMinFailure, previousMinFlake := minFailure, minFlake
+	defer func() {
+		tg = previousTestGrid
+		minFailure, minFlake = previousMinFailure, previousMinFlake
+	}()
+	tg = testgrid.NewTestGrid(server.URL)
+	minFailure, minFlake = 0, 0
+
+	summaries := make([]v1alpha1.DashboardSummary, summaryCount)
+	expectedTabNames := make([]string, summaryCount)
+	for i := range summaries {
+		tabName := fmt.Sprintf("tab-%02d", i)
+		expectedTabNames[i] = tabName
+		summaries[i] = v1alpha1.DashboardSummary{
+			OverallState:  v1alpha1.FLAKY_STATUS,
+			DashboardName: testDashboardName,
+			DashboardTab: &v1alpha1.DashboardTab{
+				TabName: tabName,
+				TabURL:  fmt.Sprintf("%s/%d", server.URL, i),
+			},
+		}
+	}
+
+	tabs := fetchDashboardTabs(summaries)
+
+	require.Len(t, tabs, summaryCount)
+	actualTabNames := make([]string, len(tabs))
+	for i, tab := range tabs {
+		actualTabNames[i] = tab.TabName
+	}
+	assert.Equal(t, expectedTabNames, actualTabNames)
+	assert.Greater(t, int(peakRequests), 1)
+	assert.LessOrEqual(t, int(peakRequests), maxConcurrentTabFetches)
+}

--- a/internal/testgrid/testgrid.go
+++ b/internal/testgrid/testgrid.go
@@ -21,6 +21,16 @@ var (
 
 const tabURL = "%s/%s/table?tab=%s&exclude-non-failed-tests=&dashboard=%s"
 
+// Values mirror TestGrid's test_status.TestStatus enum.
+const (
+	testStatusTimedOut        = 9
+	testStatusCategorizedFail = 10
+	testStatusBuildFail       = 11
+	testStatusFail            = 12
+	testStatusFlaky           = 13
+	testStatusToolFail        = 14
+)
+
 // TestGroup serializes the content from testgrid tab endpoint
 type TestGroup struct {
 	TestGroupName      string     `json:"test-group-name"`
@@ -55,26 +65,74 @@ type Statuses struct {
 }
 
 // RenderStatuses renders the statuses of a test into a string.
-func (te *Test) RenderStatuses(timestamps []int64) (string, int, int) {
-	var firstFailureIndex = -1
-	var failureCount = 0
-	var output strings.Builder
-
-	for i, shortText := range te.ShortTexts {
-		if shortText == "" {
-			continue
-		}
-
-		if firstFailureIndex < 0 {
-			firstFailureIndex = i
-		}
-
-		formattedStatus := formatTestStatus(shortText, timestamps[i], te.Messages[i])
-		output.WriteString(formattedStatus)
-		failureCount++
+func (te *Test) RenderStatuses(timestamps []int64) (string, int, int, int, error) {
+	if len(te.ShortTexts) != len(timestamps) || len(te.Messages) != len(timestamps) {
+		return "", 0, -1, -1, fmt.Errorf(
+			"column data is not aligned: %d timestamps, %d short texts, %d messages",
+			len(timestamps), len(te.ShortTexts), len(te.Messages),
+		)
 	}
 
-	return output.String(), failureCount, firstFailureIndex
+	latestFailureIndex := -1
+	firstFailureIndex := -1
+	failureCount := 0
+	columnIndex := 0
+	var output strings.Builder
+
+	for _, statusRun := range te.Statuses {
+		if statusRun.Count < 0 {
+			return "", 0, -1, -1, fmt.Errorf("status run has negative count %d", statusRun.Count)
+		}
+		for range statusRun.Count {
+			if columnIndex >= len(timestamps) {
+				return "", 0, -1, -1, fmt.Errorf(
+					"status data has more columns than the %d timestamps",
+					len(timestamps),
+				)
+			}
+			if !isFailureStatus(statusRun.Value) {
+				columnIndex++
+				continue
+			}
+
+			if latestFailureIndex < 0 {
+				latestFailureIndex = columnIndex
+			}
+			firstFailureIndex = columnIndex
+
+			formattedStatus := formatTestStatus(
+				te.ShortTexts[columnIndex],
+				timestamps[columnIndex],
+				te.Messages[columnIndex],
+			)
+			output.WriteString(formattedStatus)
+			failureCount++
+			columnIndex++
+		}
+	}
+
+	if columnIndex != len(timestamps) {
+		return "", 0, -1, -1, fmt.Errorf(
+			"status data has %d columns; expected %d",
+			columnIndex, len(timestamps),
+		)
+	}
+
+	return output.String(), failureCount, latestFailureIndex, firstFailureIndex, nil
+}
+
+func isFailureStatus(status int) bool {
+	switch status {
+	case testStatusTimedOut,
+		testStatusCategorizedFail,
+		testStatusBuildFail,
+		testStatusFail,
+		testStatusFlaky,
+		testStatusToolFail:
+		return true
+	default:
+		return false
+	}
 }
 
 type TestGrid struct {
@@ -96,6 +154,10 @@ func (t *TestGrid) FetchTabSummary(dashboard string, filterStatus []string) (sum
 	if response, err = http.Get(url); err != nil {
 		return nil, fmt.Errorf("error fetching testgrid dashboard summary endpoint: %v", err)
 	}
+	defer func() { _ = response.Body.Close() }()
+	if response.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("testgrid dashboard summary endpoint returned %s", response.Status)
+	}
 
 	var data []byte
 	if data, err = io.ReadAll(response.Body); err != nil {
@@ -107,14 +169,21 @@ func (t *TestGrid) FetchTabSummary(dashboard string, filterStatus []string) (sum
 	if err = json.Unmarshal(data, &dashboardList); err != nil {
 		return nil, fmt.Errorf("error unmarshaling body response: %v", err)
 	}
+	if dashboardList == nil {
+		return nil, fmt.Errorf("testgrid dashboard summary response is null")
+	}
 
-	return filterDashboards(dashboardList, t.URL, filterStatus), nil
+	return filterDashboards(dashboardList, t.URL, filterStatus)
 }
 
-func filterDashboards(dashboardList DashboardMapper, url string, filterStatus []string) (summary []v1alpha1.DashboardSummary) {
+func filterDashboards(dashboardList DashboardMapper, url string, filterStatus []string) ([]v1alpha1.DashboardSummary, error) {
+	summary := make([]v1alpha1.DashboardSummary, 0, len(dashboardList))
 	// iterate and save the final value filtering by status
 	// and enhance tab payload
 	for tabName, dashboardSummary := range dashboardList {
+		if dashboardSummary == nil {
+			return nil, fmt.Errorf("TestGrid summary entry %q is null", tabName)
+		}
 		if hasStatus(dashboardSummary.OverallState, filterStatus) {
 			dashboardSummary.DashboardURL = url
 			if dashboardSummary.DashboardTab == nil {
@@ -127,14 +196,22 @@ func filterDashboards(dashboardList DashboardMapper, url string, filterStatus []
 			summary = append(summary, *dashboardSummary)
 		}
 	}
-	return summary
+	return summary, nil
 }
 
 // FetchTabTests returns the test group related to the tab of a dashboard
 func (t *TestGrid) FetchTabTests(summary *v1alpha1.DashboardSummary, minFailure, minFlake int) (tab *v1alpha1.DashboardTab, err error) {
+	if summary == nil || summary.DashboardTab == nil {
+		return nil, fmt.Errorf("dashboard summary and tab must not be nil")
+	}
+
 	var response *http.Response
 	if response, err = http.Get(summary.DashboardTab.TabURL); err != nil {
 		return tab, err
+	}
+	defer func() { _ = response.Body.Close() }()
+	if response.StatusCode != http.StatusOK {
+		return tab, fmt.Errorf("testgrid table endpoint returned %s", response.Status)
 	}
 
 	var data []byte
@@ -143,32 +220,62 @@ func (t *TestGrid) FetchTabTests(summary *v1alpha1.DashboardSummary, minFailure,
 	}
 
 	// unmarshal test group and be converted into the internal dashboard format
-	var testGroup = &TestGroup{}
-	if err = json.Unmarshal(data, testGroup); err != nil {
+	var testGroup *TestGroup
+	if err = json.Unmarshal(data, &testGroup); err != nil {
 		return tab, err
+	}
+	if testGroup == nil {
+		return nil, fmt.Errorf("testgrid table response is null")
+	}
+	if len(testGroup.Changelists) != len(testGroup.Timestamps) {
+		return nil, fmt.Errorf(
+			"TestGrid column data is not aligned: %d timestamps, %d changelists",
+			len(testGroup.Timestamps), len(testGroup.Changelists),
+		)
 	}
 
 	aggregation := fmt.Sprintf("%s#%s", summary.DashboardName, summary.DashboardTab.TabName)
+	tabState := summary.OverallState
+	filterState := tabState
+	if filterState == v1alpha1.PASSING_STATUS {
+		filterState = v1alpha1.FLAKY_STATUS
+		minFlake = max(minFlake, 1)
+	}
+	testRuns, err := filterTabTests(testGroup, filterState, minFailure, minFlake)
+	if err != nil {
+		return nil, err
+	}
+	if tabState == v1alpha1.PASSING_STATUS && len(testRuns) > 0 {
+		tabState = v1alpha1.FLAKY_STATUS
+	}
+
 	icon := ":large_purple_square:"
-	if summary.OverallState == v1alpha1.FAILING_STATUS {
+	switch tabState {
+	case v1alpha1.FAILING_STATUS:
 		icon = ":large_red_square:"
+	case v1alpha1.PASSING_STATUS:
+		icon = ":large_green_square:"
 	}
 
 	summary.DashboardTab.BoardHash = aggregation
 	summary.DashboardTab.TabURL = cleanHTMLCharacters(fmt.Sprintf("https://testgrid.k8s.io/%s&exclude-non-failed-tests=", aggregation))
-	summary.DashboardTab.TestRuns = filterTabTests(testGroup, summary.OverallState, minFailure, minFlake)
-	summary.DashboardTab.TabState = summary.OverallState
+	summary.DashboardTab.TestRuns = testRuns
+	summary.DashboardTab.TabState = tabState
 	summary.DashboardTab.StateIcon = icon
 
 	return summary.DashboardTab, nil
 }
 
-func filterTabTests(testGroup *TestGroup, state string, minFailure, minFlake int) (tests []v1alpha1.TestResult) {
+func filterTabTests(testGroup *TestGroup, state string, minFailure, minFlake int) ([]v1alpha1.TestResult, error) {
+	tests := make([]v1alpha1.TestResult, 0)
 	jobName := strings.Split(testGroup.Query, "/")
 	for _, test := range testGroup.Tests {
-		errMessage, failures, firstFailure := test.RenderStatuses(testGroup.Timestamps)
-		if ((failures >= minFailure || minFailure == 0) && state == v1alpha1.FAILING_STATUS) ||
-			((failures >= minFlake || minFlake == 0) && state == v1alpha1.FLAKY_STATUS) {
+		errMessage, failures, latestFailure, firstFailure, err := test.RenderStatuses(testGroup.Timestamps)
+		if err != nil {
+			return nil, fmt.Errorf("invalid TestGrid row %q: %w", test.Name, err)
+		}
+		if failures > 0 && (((failures >= minFailure || minFailure == 0) && state == v1alpha1.FAILING_STATUS) ||
+			((failures >= minFlake || minFlake == 0) && state == v1alpha1.FLAKY_STATUS)) {
 			testName := test.Name
 			if strings.Contains(testName, e2eSuitePrefix) {
 				testName = prow.GetRegexParameter(testRegex, testName)["TEST"]
@@ -177,21 +284,27 @@ func filterTabTests(testGroup *TestGroup, state string, minFailure, minFlake int
 				testName = strings.TrimPrefix(strings.TrimPrefix(testName, "kubetest2."), "kubetest.")
 			}
 
+			latestTimestamp := testGroup.Timestamps[0]
+			firstTimestamp := testGroup.Timestamps[len(testGroup.Timestamps)-1]
 			var prowJobURL string
-			if firstFailure >= 0 && firstFailure < len(testGroup.Changelists) {
-				prowJobURL = cleanHTMLCharacters(fmt.Sprintf("https://prow.k8s.io/view/gs/%s/%s", testGroup.Query, testGroup.Changelists[firstFailure]))
+			if latestFailure >= 0 && latestFailure < len(testGroup.Changelists) {
+				prowJobURL = cleanHTMLCharacters(fmt.Sprintf("https://prow.k8s.io/view/gs/%s/%s", testGroup.Query, testGroup.Changelists[latestFailure]))
+			}
+			if latestFailure >= 0 {
+				latestTimestamp = testGroup.Timestamps[latestFailure]
+				firstTimestamp = testGroup.Timestamps[firstFailure]
 			}
 			tests = append(tests, v1alpha1.TestResult{
 				TestName:        test.Name,
-				LatestTimestamp: testGroup.Timestamps[0],
-				FirstTimestamp:  testGroup.Timestamps[len(testGroup.Timestamps)-1],
+				LatestTimestamp: latestTimestamp,
+				FirstTimestamp:  firstTimestamp,
 				ProwJobURL:      prowJobURL,
 				TriageURL:       cleanHTMLCharacters(fmt.Sprintf("https://storage.googleapis.com/k8s-triage/index.html?job=%s$&test=%s", cleanHTMLCharacters(jobName[len(jobName)-1]), cleanHTMLCharacters(testName))),
 				ErrorMessage:    errMessage,
 			})
 		}
 	}
-	return tests
+	return tests, nil
 }
 
 func hasStatus(boardStatus string, statuses []string) bool {

--- a/internal/testgrid/testgrid_test.go
+++ b/internal/testgrid/testgrid_test.go
@@ -7,10 +7,21 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"sigs.k8s.io/signalhound/api/v1alpha1"
 )
 
-const dashboard, tabName = "sig-release-blocking", "kubernetes-ci"
+const (
+	dashboard       = "sig-release-blocking"
+	tabName         = "kubernetes-ci"
+	testDashboard   = "dashboard-test"
+	testTab         = "tab-test"
+	testGroupName   = "cikubernetese2ecapzmasterwindows"
+	testGroupQuery  = "kubernetes-ci-logs/logs/ci-kubernetes-e2e-capz-master-windows"
+	overallTestName = "ci-kubernetes-build.Overall"
+	testStatusPass  = 1
+	testStatusRun   = 4
+)
 
 func Test_FetchSummary(t *testing.T) {
 	tests := []struct {
@@ -72,25 +83,144 @@ func Test_FetchSummary(t *testing.T) {
 	}
 }
 
+func TestFetchSummaryRejectsNullEntries(t *testing.T) {
+	server := startServer(DashboardMapper{tabName: nil})
+	defer server.Close()
+
+	_, err := NewTestGrid(server.URL).FetchTabSummary(dashboard, []string{v1alpha1.PASSING_STATUS})
+
+	assert.ErrorContains(t, err, "summary entry")
+}
+
+func TestFetchSummaryRejectsNullResponse(t *testing.T) {
+	server := startServer(nil)
+	defer server.Close()
+
+	_, err := NewTestGrid(server.URL).FetchTabSummary(dashboard, []string{v1alpha1.PASSING_STATUS})
+
+	assert.ErrorContains(t, err, "summary response is null")
+}
+
 func Test_FetchTable(t *testing.T) {
 	tests := []struct {
-		name      string
-		dashboard string
-		tab       string
-		response  TestGroup
+		name            string
+		dashboard       string
+		tab             string
+		overallState    string
+		response        TestGroup
+		minFailure      int
+		minFlake        int
+		expectedState   string
+		expectedRuns    int
+		expectedLatest  int64
+		expectedFirst   int64
+		expectedProwRun string
 	}{
 		{
-			name:      "successful fetch",
-			dashboard: "dashboard-test",
-			tab:       "tab-test",
+			name:            "flaky tab includes failed tests",
+			dashboard:       testDashboard,
+			tab:             testTab,
+			overallState:    v1alpha1.FLAKY_STATUS,
+			minFailure:      1,
+			minFlake:        1,
+			expectedState:   v1alpha1.FLAKY_STATUS,
+			expectedRuns:    1,
+			expectedLatest:  1758999193000,
+			expectedFirst:   1758999193000,
+			expectedProwRun: "1972011571991285760",
 			response: TestGroup{
-				TestGroupName: "cikubernetese2ecapzmasterwindows",
-				Query:         "kubernetes-ci-logs/logs/ci-kubernetes-e2e-capz-master-windows",
+				TestGroupName: testGroupName,
+				Query:         testGroupQuery,
 				Status:        "Served from cache in 0.16 seconds",
 				Timestamps:    []int64{1758999193000},
 				Changelists:   []string{"1972011571991285760"},
 				Tests: []Test{
-					{Name: "ci-kubernetes-build.Overall", ShortTexts: []string{"F"}, Messages: []string{"F"}},
+					{
+						Name:       overallTestName,
+						ShortTexts: []string{"F"},
+						Messages:   []string{"F"},
+						Statuses:   []Statuses{{Count: 1, Value: testStatusFail}},
+					},
+				},
+			},
+		},
+		{
+			name:            "passing tab with historical failures is flaky",
+			dashboard:       testDashboard,
+			tab:             testTab,
+			overallState:    v1alpha1.PASSING_STATUS,
+			minFailure:      1,
+			minFlake:        1,
+			expectedState:   v1alpha1.FLAKY_STATUS,
+			expectedRuns:    1,
+			expectedLatest:  1758999192000,
+			expectedFirst:   1758999190000,
+			expectedProwRun: "latest-failed-run",
+			response: TestGroup{
+				TestGroupName: testGroupName,
+				Query:         testGroupQuery,
+				Timestamps:    []int64{1758999193000, 1758999192000, 1758999191000, 1758999190000},
+				Changelists:   []string{"successful-run", "latest-failed-run", "another-successful-run", "first-failed-run"},
+				Tests: []Test{
+					{
+						Name:       overallTestName,
+						ShortTexts: []string{"2/2", "1/2", "2/2", "F"},
+						Messages:   []string{"2/2 runs passed", "1/2 runs passed", "2/2 runs passed", "F"},
+						Statuses: []Statuses{
+							{Count: 1, Value: testStatusPass},
+							{Count: 1, Value: testStatusFlaky},
+							{Count: 1, Value: testStatusPass},
+							{Count: 1, Value: testStatusFail},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:          "passing tab without historical failures remains passing",
+			dashboard:     testDashboard,
+			tab:           testTab,
+			overallState:  v1alpha1.PASSING_STATUS,
+			minFailure:    0,
+			minFlake:      0,
+			expectedState: v1alpha1.PASSING_STATUS,
+			expectedRuns:  0,
+			response: TestGroup{
+				TestGroupName: testGroupName,
+				Query:         testGroupQuery,
+				Timestamps:    []int64{1758999193000},
+				Changelists:   []string{"1972011571991285760"},
+				Tests: []Test{
+					{
+						Name:       overallTestName,
+						ShortTexts: []string{"2/2"},
+						Messages:   []string{"2/2 runs passed"},
+						Statuses:   []Statuses{{Count: 1, Value: testStatusPass}},
+					},
+				},
+			},
+		},
+		{
+			name:          "passing tab below flake threshold remains passing",
+			dashboard:     testDashboard,
+			tab:           testTab,
+			overallState:  v1alpha1.PASSING_STATUS,
+			minFailure:    1,
+			minFlake:      2,
+			expectedState: v1alpha1.PASSING_STATUS,
+			expectedRuns:  0,
+			response: TestGroup{
+				TestGroupName: testGroupName,
+				Query:         testGroupQuery,
+				Timestamps:    []int64{1758999193000},
+				Changelists:   []string{"1972011571991285760"},
+				Tests: []Test{
+					{
+						Name:       overallTestName,
+						ShortTexts: []string{"F"},
+						Messages:   []string{"F"},
+						Statuses:   []Statuses{{Count: 1, Value: testStatusFail}},
+					},
 				},
 			},
 		},
@@ -102,24 +232,27 @@ func Test_FetchTable(t *testing.T) {
 			defer server.Close()
 
 			summary := &v1alpha1.DashboardSummary{
-				OverallState:  v1alpha1.FLAKY_STATUS,
-				DashboardName: dashboard,
+				OverallState:  tt.overallState,
+				DashboardName: tt.dashboard,
 				DashboardTab: &v1alpha1.DashboardTab{
-					TabName: "cikubernetesbuild",
+					TabName: tt.tab,
 					TabURL:  server.URL,
 				},
 			}
 
 			tg := NewTestGrid(server.URL)
-			tabTest, err := tg.FetchTabTests(summary, 1, 1)
-			assert.NoError(t, err)
+			tabTest, err := tg.FetchTabTests(summary, tt.minFailure, tt.minFlake)
+			require.NoError(t, err)
 
 			assert.NotEmpty(t, tabTest.StateIcon)
-			assert.Equal(t, v1alpha1.FLAKY_STATUS, tabTest.TabState)
-			assert.Len(t, tabTest.TestRuns, 1)
+			assert.Equal(t, tt.expectedState, tabTest.TabState)
+			assert.Len(t, tabTest.TestRuns, tt.expectedRuns)
 			for _, test := range tabTest.TestRuns {
 				assert.Contains(t, test.TestName, "Overall")
 				assert.Contains(t, test.ErrorMessage, "F")
+				assert.Equal(t, tt.expectedLatest, test.LatestTimestamp)
+				assert.Equal(t, tt.expectedFirst, test.FirstTimestamp)
+				assert.Contains(t, test.ProwJobURL, tt.expectedProwRun)
 			}
 		})
 	}
@@ -133,40 +266,171 @@ func TestRenderStatuses(t *testing.T) {
 		inputTimestamps []int64
 		expectedOutput  string
 		expectedCount   int
-		expectedIndex   int
+		expectedLatest  int
+		expectedFirst   int
 	}{
 		{
-			name: "all short texts must match timestamp",
+			name: "only failure statuses are rendered",
 			inputTest: Test{
-				ShortTexts: []string{"", "", "F", "", "F"},
-				Messages:   []string{"", "", message, "", message},
+				ShortTexts: []string{"2/2", "R", "1/2", "16/16", "F"},
+				Messages:   []string{"2/2 runs passed", "Build still running...", message, "16/16 runs passed", message},
+				Statuses: []Statuses{
+					{Count: 1, Value: testStatusPass},
+					{Count: 1, Value: testStatusRun},
+					{Count: 1, Value: testStatusFlaky},
+					{Count: 1, Value: testStatusPass},
+					{Count: 1, Value: testStatusFail},
+				},
 			},
 			inputTimestamps: []int64{1758974631000, 1758967371000, 1758960111000, 1758952851000, 1758945591000},
-			expectedOutput:  formatTestStatus("F", 1758960111000, message) + formatTestStatus("F", 1758945591000, message),
-			expectedIndex:   2,
+			expectedOutput:  formatTestStatus("1/2", 1758960111000, message) + formatTestStatus("F", 1758945591000, message),
+			expectedLatest:  2,
+			expectedFirst:   4,
 			expectedCount:   2,
 		},
 		{
 			name: "no statuses to render",
 			inputTest: Test{
-				ShortTexts: []string{"", "", ""},
-				Messages:   []string{"", "", ""},
+				ShortTexts: []string{"2/2", "R", "16/16"},
+				Messages:   []string{"passed", "running", "passed"},
+				Statuses: []Statuses{
+					{Count: 1, Value: testStatusPass},
+					{Count: 1, Value: testStatusRun},
+					{Count: 1, Value: testStatusPass},
+				},
 			},
 			inputTimestamps: []int64{1620000000, 1620003600, 1620007200},
 			expectedOutput:  "",
 			expectedCount:   0,
-			expectedIndex:   -1,
+			expectedLatest:  -1,
+			expectedFirst:   -1,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			output, failureCount, firstFailureIndex := tt.inputTest.RenderStatuses(tt.inputTimestamps)
+			output, failureCount, latestFailureIndex, firstFailureIndex, err := tt.inputTest.RenderStatuses(tt.inputTimestamps)
+			require.NoError(t, err)
 			assert.Equal(t, tt.expectedOutput, output)
 			assert.Equal(t, tt.expectedCount, failureCount)
-			assert.Equal(t, tt.expectedIndex, firstFailureIndex)
+			assert.Equal(t, tt.expectedLatest, latestFailureIndex)
+			assert.Equal(t, tt.expectedFirst, firstFailureIndex)
 		})
 	}
+}
+
+func TestRenderStatusesRejectsMisalignedColumns(t *testing.T) {
+	tests := []struct {
+		name       string
+		test       Test
+		timestamps []int64
+		errText    string
+	}{
+		{
+			name: "message count differs from timestamps",
+			test: Test{
+				ShortTexts: []string{"F", "F"},
+				Messages:   []string{"failed"},
+				Statuses:   []Statuses{{Count: 2, Value: testStatusFail}},
+			},
+			timestamps: []int64{1, 2},
+			errText:    "column data is not aligned",
+		},
+		{
+			name: "status count differs from timestamps",
+			test: Test{
+				ShortTexts: []string{"F", "F"},
+				Messages:   []string{"failed", "failed"},
+				Statuses:   []Statuses{{Count: 1, Value: testStatusFail}},
+			},
+			timestamps: []int64{1, 2},
+			errText:    "status data has 1 columns; expected 2",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, _, _, err := tt.test.RenderStatuses(tt.timestamps)
+			assert.ErrorContains(t, err, tt.errText)
+		})
+	}
+}
+
+func TestFetchTabTestsRejectsMisalignedRows(t *testing.T) {
+	server := startServer(TestGroup{
+		Query:       testGroupQuery,
+		Timestamps:  []int64{1, 2},
+		Changelists: []string{"run-1", "run-2"},
+		Tests: []Test{
+			{
+				Name:       overallTestName,
+				ShortTexts: []string{"F", "F"},
+				Messages:   []string{"failed"},
+				Statuses:   []Statuses{{Count: 2, Value: testStatusFail}},
+			},
+		},
+	})
+	defer server.Close()
+
+	summary := &v1alpha1.DashboardSummary{
+		OverallState:  v1alpha1.PASSING_STATUS,
+		DashboardName: testDashboard,
+		DashboardTab: &v1alpha1.DashboardTab{
+			TabName: testTab,
+			TabURL:  server.URL,
+		},
+	}
+
+	_, err := NewTestGrid(server.URL).FetchTabTests(summary, 1, 1)
+
+	assert.ErrorContains(t, err, "column data is not aligned")
+}
+
+func TestFetchTabTestsRejectsNullResponse(t *testing.T) {
+	server := startServer(nil)
+	defer server.Close()
+
+	summary := &v1alpha1.DashboardSummary{
+		OverallState:  v1alpha1.PASSING_STATUS,
+		DashboardName: testDashboard,
+		DashboardTab: &v1alpha1.DashboardTab{
+			TabName: testTab,
+			TabURL:  server.URL,
+		},
+	}
+
+	_, err := NewTestGrid(server.URL).FetchTabTests(summary, 1, 1)
+
+	assert.ErrorContains(t, err, "table response is null")
+}
+
+func TestFetchTabTestsRejectsMisalignedChangelists(t *testing.T) {
+	server := startServer(TestGroup{
+		Query:      testGroupQuery,
+		Timestamps: []int64{1},
+		Tests: []Test{
+			{
+				Name:       overallTestName,
+				ShortTexts: []string{"F"},
+				Messages:   []string{"failed"},
+				Statuses:   []Statuses{{Count: 1, Value: testStatusFail}},
+			},
+		},
+	})
+	defer server.Close()
+
+	summary := &v1alpha1.DashboardSummary{
+		OverallState:  v1alpha1.PASSING_STATUS,
+		DashboardName: testDashboard,
+		DashboardTab: &v1alpha1.DashboardTab{
+			TabName: testTab,
+			TabURL:  server.URL,
+		},
+	}
+
+	_, err := NewTestGrid(server.URL).FetchTabTests(summary, 1, 1)
+
+	assert.ErrorContains(t, err, "1 timestamps, 0 changelists")
 }
 
 func startServer(response interface{}) *httptest.Server {


### PR DESCRIPTION
Fixes #22

Signalhound currently skips table data for tabs whose TestGrid summary has returned to passing. That hides failures still present in the tab history, which is common for hourly jobs after a short run of successful builds.

This change also inspects passing tabs and reports them as flaky only when their table history contains actual failure statuses. Table requests are bounded so the additional lookups do not run serially or without a limit.

## Verification

- `make test`
- `go test -race ./internal/testgrid ./cmd`
